### PR TITLE
Fixes Bloomscape name typo

### DIFF
--- a/src/components/Community.js
+++ b/src/components/Community.js
@@ -104,7 +104,7 @@ class Community extends Component {
               src={logoBloomscape}
               location="Detroit, MI"
               href="https://www.bloomscape.com/"
-              name="Benzinga"
+              name="Bloomscape"
               type="Startup"
             />
             <Logo


### PR DESCRIPTION
Unless there's something I'm missing, Bloomscape != Benzinga. This is a quick typo fix. 

![image](https://user-images.githubusercontent.com/10940268/43413548-5176d054-93fe-11e8-9a93-69bdd5436b66.png)

/cc @shriyash 